### PR TITLE
Integrate React95 theme components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,28 @@
-# React + TypeScript + Vite
+# Win95 Portfolio
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project uses the [react95](https://github.com/arturbien/React95) component library to mimic the classic Windows 95 interface.
 
-Currently, two official plugins are available:
+## Development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Install dependencies and run the dev server:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default {
-  // other rules...
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json'],
-    tsconfigRootDir: __dirname,
-  },
-}
+```bash
+npm install
+npm run dev
 ```
 
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+## Build
+
+Create an optimized production build with:
+
+```bash
+npm run build
+```
+
+Preview the built app locally:
+
+```bash
+npm run preview
+```
+
+You can customize the portfolio content by editing the placeholder sections in the React components.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,42 +1,16 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import StartMenu from './StartMenu'
+import PortfolioWindow from './PortfolioWindow'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [section, setSection] = useState<'about' | 'projects' | 'contact'>('about')
 
   return (
-    <>
-      <div>
-        <a
-          href="https://vitejs.dev"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a
-          href="https://react.dev"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="App">
+      <StartMenu onSelect={setSection} />
+      <PortfolioWindow active={section} />
+    </div>
   )
 }
 

--- a/src/PortfolioWindow.tsx
+++ b/src/PortfolioWindow.tsx
@@ -1,0 +1,29 @@
+import { Window, WindowContent, WindowHeader } from 'react95'
+
+interface PortfolioWindowProps {
+  active: 'about' | 'projects' | 'contact'
+}
+
+const PortfolioWindow = ({ active }: PortfolioWindowProps) => {
+  const renderSection = () => {
+    switch (active) {
+      case 'about':
+        return <div>About section placeholder</div>
+      case 'projects':
+        return <div>Projects section placeholder</div>
+      case 'contact':
+        return <div>Contact section placeholder</div>
+      default:
+        return <div>Select a section from the Start menu.</div>
+    }
+  }
+
+  return (
+    <Window style={{ width: '600px', margin: '1rem auto' }}>
+      <WindowHeader>My Portfolio</WindowHeader>
+      <WindowContent>{renderSection()}</WindowContent>
+    </Window>
+  )
+}
+
+export default PortfolioWindow

--- a/src/StartMenu.tsx
+++ b/src/StartMenu.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { Button, List, ListItem } from 'react95'
+
+interface StartMenuProps {
+  onSelect: (section: 'about' | 'projects' | 'contact') => void
+}
+
+const StartMenu = ({ onSelect }: StartMenuProps) => {
+  const [open, setOpen] = useState(false)
+
+  const handleSelect = (section: 'about' | 'projects' | 'contact') => {
+    setOpen(false)
+    onSelect(section)
+  }
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      <Button onClick={() => setOpen((o) => !o)}>Start</Button>
+      {open && (
+        <List style={{ position: 'absolute', bottom: '100%', left: 0 }}>
+          <ListItem onClick={() => handleSelect('about')}>About</ListItem>
+          <ListItem onClick={() => handleSelect('projects')}>Projects</ListItem>
+          <ListItem onClick={() => handleSelect('contact')}>Contact</ListItem>
+        </List>
+      )}
+    </div>
+  )
+}
+
+export default StartMenu

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { ThemeProvider } from 'styled-components'
+import original from 'react95/dist/themes/original'
 import App from './App.tsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={original}>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add React95 theme and ThemeProvider
- implement StartMenu and PortfolioWindow components
- display new components in App
- simplify README with Windows 95 styling info

## Testing
- `npm run build` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_683f448ba6a8832b9bbefbd51ea405e2